### PR TITLE
Add internal tools

### DIFF
--- a/Formula/gazelle.rb
+++ b/Formula/gazelle.rb
@@ -1,0 +1,18 @@
+require "formula"
+require_relative "lib/private_strategy"
+
+class Gazelle < Formula
+  desc "Gazelle Schema code generator and validator"
+  homepage "https://github.com/ArtProcessors/ap-gazelle-schema-mobile"
+  url "https://github.com/ArtProcessors/ap-gazelle-schema-mobile/releases/download/2.6.1/gazelle.zip", :using => GitHubPrivateRepositoryReleaseDownloadStrategy
+  version "2.6.1"
+  sha256 "0edf94ee4f7158a45e80fcfb29bd2e530d53afa8311d7cfbc1d55b3b5758bd4a"
+
+  def install
+    bin.install "gazelle"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/gazelle --version")
+  end
+end

--- a/Formula/lib/private_strategy.rb
+++ b/Formula/lib/private_strategy.rb
@@ -1,0 +1,147 @@
+# Save this file as `lib/private_strategy.rb`
+# Add `require_relative "lib/private_strategy"` to your formula.
+# 
+# This is based on the following, with minor fixes.
+# https://github.com/Homebrew/brew/blob/193af1442f6b9a19fa71325160d0ee2889a1b6c9/Library/Homebrew/compat/download_strategy.rb#L48-L157
+
+# BSD 2-Clause License
+#
+# Copyright (c) 2009-present, Homebrew contributors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# GitHubPrivateRepositoryDownloadStrategy downloads contents from GitHub
+# Private Repository. To use it, add
+# `:using => GitHubPrivateRepositoryDownloadStrategy` to the URL section of
+# your formula. This download strategy uses GitHub access tokens (in the
+# environment variables `HOMEBREW_GITHUB_API_TOKEN`) to sign the request.  This
+# strategy is suitable for corporate use just like S3DownloadStrategy, because
+# it lets you use a private GitHub repository for internal distribution.  It
+# works with public one, but in that case simply use CurlDownloadStrategy.
+class EnvironmentMissingError < StandardError
+
+end
+
+class AccessDeniedError < StandardError
+
+end
+
+class GitHubPrivateRepositoryDownloadStrategy < CurlDownloadStrategy
+    require "utils/formatter"
+    require "utils/github"
+  
+    def initialize(url, name, version, **meta)
+      super
+      parse_url_pattern
+      set_github_token
+    end
+  
+    def parse_url_pattern
+      unless match = url.match(%r{https://github.com/([^/]+)/([^/]+)/(\S+)})
+        raise CurlDownloadStrategyError, "Invalid url pattern for GitHub Repository."
+      end
+  
+      _, @owner, @repo, @filepath = *match
+    end
+  
+    def download_url
+      "https://#{@github_token}@github.com/#{@owner}/#{@repo}/#{@filepath}"
+    end
+  
+    private
+  
+    def _fetch(url:, resolved_url:, timeout:)
+      curl_download download_url, to: temporary_path
+    end
+  
+    def set_github_token
+      @github_token = ENV["HOMEBREW_GITHUB_API_TOKEN"]
+      unless @github_token
+        raise EnvironmentMissingError, "Environmental variable HOMEBREW_GITHUB_API_TOKEN is required."
+      end
+  
+      validate_github_repository_access!
+    end
+  
+    def validate_github_repository_access!
+      # Test access to the repository
+      GitHub.repository(@owner, @repo)
+    rescue GitHub::API::HTTPNotFoundError, GitHub::API::AuthenticationFailedError
+      # We switched to GitHub::API::HTTPNotFoundError, 
+      # because we can now handle bad credentials messages
+      message = <<~EOS
+        HOMEBREW_GITHUB_API_TOKEN can not access the repository: #{@owner}/#{@repo}
+        This token may not have permission to access the repository or the url of formula may be incorrect.
+      EOS
+      raise AccessDeniedError, message
+    end
+  end
+  
+  # GitHubPrivateRepositoryReleaseDownloadStrategy downloads tarballs from GitHub
+  # Release assets. To use it, add
+  # `:using => GitHubPrivateRepositoryReleaseDownloadStrategy` to the URL section of
+  # your formula. This download strategy uses GitHub access tokens (in the
+  # environment variables HOMEBREW_GITHUB_API_TOKEN) to sign the request.
+  class GitHubPrivateRepositoryReleaseDownloadStrategy < GitHubPrivateRepositoryDownloadStrategy
+    def initialize(url, name, version, **meta)
+      super
+    end
+  
+    def parse_url_pattern
+      url_pattern = %r{https://github.com/([^/]+)/([^/]+)/releases/download/([^/]+)/(\S+)}
+      unless @url =~ url_pattern
+        raise CurlDownloadStrategyError, "Invalid url pattern for GitHub Release."
+      end
+  
+      _, @owner, @repo, @tag, @filename = *@url.match(url_pattern)
+    end
+  
+    def download_url
+      "https://#{@github_token}@api.github.com/repos/#{@owner}/#{@repo}/releases/assets/#{asset_id}"
+    end
+  
+    private
+  
+    def _fetch(url:, resolved_url:, timeout:)
+      # HTTP request header `Accept: application/octet-stream` is required.
+      # Without this, the GitHub API will respond with metadata, not binary.
+      curl_download download_url, "--header", "Accept: application/octet-stream", to: temporary_path
+    end
+  
+    def asset_id
+      @asset_id ||= resolve_asset_id
+    end
+  
+    def resolve_asset_id
+      release_metadata = fetch_release_metadata
+      assets = release_metadata["assets"].select { |a| a["name"] == @filename }
+      raise CurlDownloadStrategyError, "Asset file not found." if assets.empty?
+  
+      assets.first["id"]
+    end
+  
+    def fetch_release_metadata
+      release_url = "https://api.github.com/repos/#{@owner}/#{@repo}/releases/tags/#{@tag}"
+      GitHub::API.open_rest(release_url)
+    end
+  end

--- a/Formula/poeditor.rb
+++ b/Formula/poeditor.rb
@@ -1,0 +1,18 @@
+require "formula"
+require_relative "lib/private_strategy"
+
+class Poeditor < Formula
+  desc "POEditor CLI tool"
+  homepage "https://github.com/ArtProcessors/ap-poeditor-tool-macos"
+  url "https://github.com/ArtProcessors/ap-poeditor-tool-macos/releases/download/2.5.0/poeditor.zip", :using => GitHubPrivateRepositoryReleaseDownloadStrategy
+  version "2.5.0"
+  sha256 "e391343da3a2fdeaa5fc1c14e70fc7027f75753ccf360cdac9a52cce9a2b493d"
+
+  def install
+    bin.install "poeditor"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/poeditor --version")
+  end
+end

--- a/Formula/vxbundler.rb
+++ b/Formula/vxbundler.rb
@@ -1,0 +1,18 @@
+require "formula"
+require_relative "lib/private_strategy"
+
+class Vxbundler < Formula
+  desc "Vixen content bundle and asset downloader"
+  homepage "https://github.com/ArtProcessors/apsys-vixen-bundler-macos"
+  url "https://github.com/ArtProcessors/apsys-vixen-bundler-macos/releases/download/1.0.1/vxbundler.zip", :using => GitHubPrivateRepositoryReleaseDownloadStrategy
+  version "1.0.1"
+  sha256 "c8e7f5fb178f065781b0c37edb00b58a4cceaa5b681696582a7e1ac4cadc2372"
+
+  def install
+    bin.install "vxbundler"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/vxbundler --version")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -3,19 +3,31 @@ Art Processors Homebrew Tap
 
 This repository exists to house Homebrew formulas for AP-maintained tools.
 At the moment, this consists of:
-* amazon-ecs-cli.rb: our fork of Amazon's ecs-cli tool, updated to support clusters with amd64 Fargate tasks and to allow the enable_execute_command flag.
+* `amazon-ecs-cli.rb`: our fork of Amazon's ecs-cli tool, updated to support clusters with amd64 Fargate tasks and to allow the enable_execute_command flag.
+* `gazelle.rb` [internal]: Gazelle Schema code generator and validator.
+* `poeditor.rb` [internal]: POEditor CLI tool.
+* `vxbundler.rb` [internal]: Vixen content bundle and asset downloader.
 
 # How to use
-Installing ecs-cli should be as simple as:
+
+Installing `ecs-cli` should be as simple as:
 ```bash
 brew install artprocessors/tap/amazon-ecs-cli
 ```
+
+To install internal tools such as `gazelle` or `poeditor`, first set the `HOMEBREW_GITHUB_API_TOKEN` environment variable to your personal GitHub API Token, e.g.:
+```bash
+export HOMEBREW_GITHUB_API_TOKEN=your-API-token
+brew install artprocessors/tap/poeditor
+```
+
+You can create an API token on [this page](https://github.com/settings/tokens).
+
 # How to develop
 
 Mac users, the easiest way to get started is to check out the repository using homebrew:
 ```bash
 $ brew tap artprocessors/tap
-
 ```
 
 From there, you can also symlink the resulting directory into another place on your local filesystem:


### PR DESCRIPTION
This PR adds formulas for our internal tools used by mobile engineers to the tap, and updates the readme to reflect that and instruct on how to install them.

The main chunk of the PR is actually a download strategy required for Homebrew to access the private repos that host our internal tools. This is a very common approach, and its implementation (based on the [code from an older version of Homebrew itself](https://github.com/Homebrew/brew/blob/193af1442f6b9a19fa71325160d0ee2889a1b6c9/Library/Homebrew/compat/download_strategy.rb#L48-L157), since removed from it) has circulated the internet for years. The one used here in particular is taken from [here](https://github.com/jamf/homebrew-tap/blob/master/Formula/lib/private.rb).

[APM-1409](https://artprocessors.atlassian.net/browse/APM-1409)

[APM-1409]: https://artprocessors.atlassian.net/browse/APM-1409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ